### PR TITLE
Only remove excercise folders, not everything

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,5 +4,5 @@ checkoutLocation: '.'
 tasks:
   - name: Clean root and grab useful exercises.
     before: |
-      rm -rfv ./{*,.*}
+      rm -rfv ./exercise*
       mv /home/gitpod/git-exercices/* .


### PR DESCRIPTION
The full rm deletes the .gitpod folder which then gives an error on every command since gitpod wants to write a history file to that folder. 