### PR TITLE
Migrate to GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "version_control_with_git",
+  "build": {
+    "dockerfile": "../Dockerfile"
+  },
+  "postStartCommand": ".devcontainer/scripts/start.sh",
+  "remoteUser": "vscode",
+  "containerUser": "vscode",
+  "workspaceFolder": "/workspace/version_control_with_git",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/version_control_with_git,type=bind"
+}

--- a/.devcontainer/scripts/start.sh
+++ b/.devcontainer/scripts/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rfv ./exercise* ./.git ./content
+mv "$HOME"/git-exercices/* .

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,0 @@
-image:
-  file: .gitpod.Dockerfile
-checkoutLocation: '.'
-tasks:
-  - name: Clean root and grab useful exercises.
-    before: |
-      rm -rfv ./exercise* ./.git ./content
-      mv /home/gitpod/git-exercices/* .
-      clear

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM gitpod/workspace-full
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.13-bookworm
 
 # This env var is used to force the 
-# rebuild of the Gitpod environment when needed
+# rebuild of the GitHub Codespaces environment when needed
 ENV TRIGGER_REBUILD 1
 
 # Gets rid of extra output in the cli
@@ -13,11 +13,11 @@ RUN git config --system user.email "trainee@dataminded.be" && \
   git config --global user.name "Git trainee" && \
   git config --global init.defaultBranch master
 
-USER gitpod
-
+USER vscode
+ENV HOME /home/vscode
 # Copy exercices content into the image
-COPY --chown=gitpod content/ /home/gitpod/git-exercices
+COPY --chown=vscode content/ $HOME/git-exercices
 
 # Set up the exercices
-RUN /bin/bash /home/gitpod/git-exercices/resources/bootstrap.sh && \
-  sudo rm -rf /home/gitpod/git-exercices/resources
+RUN /bin/bash $HOME/git-exercices/resources/bootstrap.sh && \
+  sudo rm -rf $HOME/git-exercices/resources

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,14 @@ ENV TRIGGER_REBUILD 1
 ENV GIT_DISCOVERY_ACROSS_FILESYSTEM=true
 
 USER root
+ENV HOME /home/vscode
 
-RUN git config --system user.email "trainee@dataminded.be" && \
-  git config --global user.name "Git trainee" && \
+RUN git config --global user.name "Git trainee" && \
+  git config --global user.email "trainee@dataminded.be" && \
   git config --global init.defaultBranch master
 
 USER vscode
-ENV HOME /home/vscode
+
 # Copy exercices content into the image
 COPY --chown=vscode content/ $HOME/git-exercices
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Data Minded Academy - Introduction to Git
 ## Exercises Repository
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/datamindedacademy/version_control_with_git)
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/datamindedacademy/version_control_with_git)
 
 This repository is hosting the exercises provided to students in the context of the `Introduction to Git` course of the Data Minded Academy.
 
@@ -52,6 +53,6 @@ The following exercises are part of the repository:
 
 ## 2. How-to run
 
-This exercise workshop can be run directly on Gitpod (without any need to provision VM or anything) or in a regular Cloud VM. The sections below explain how to run on a Cloud VM. For Gitpod run, you just need to click the button below.
+This exercise workshop can be run directly on GitHub Codespaces (without any need to provision VM or anything) or in a regular Cloud VM. The sections below explain how to run on a Cloud VM. To open a workspace, you just need to click the button below.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/datamindedacademy/version_control_with_git)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/datamindedacademy/version_control_with_git)

--- a/content/resources/bootstrap.sh
+++ b/content/resources/bootstrap.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 ROOT="$(dirname "$0")/.."
-cd $ROOT
+cd "$ROOT" || exit
 
 for EXERCISE in $(ls resources | grep exercise); do
     echo "-------------------------------"
     echo "... Boostraping $EXERCISE ..."
     echo "-------------------------------"
-    mkdir $EXERCISE
-    ./resources/$EXERCISE/bootstrap.sh
+    mkdir "$EXERCISE"
+    ./resources/"$EXERCISE"/bootstrap.sh
 done

--- a/content/resources/exercise_7/bootstrap.sh
+++ b/content/resources/exercise_7/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ROOT="$(dirname "$0")/../.."
-cd "$ROOT/exercise_7"
+cd "$ROOT/exercise_7" || exit
 
 RESOURCES_EX7="../resources/exercise_7"
 


### PR DESCRIPTION
This PR migrates the Version Control with Git course from Gitpod to GitHub Codespaces.

Gitpod is currently switching to a different offering, called Gitpod Flex. Gitpod Classic, the SaaS offering, is only accessible to users who signed up before October 2024, and can therefore not be expected to be available to participants of our seasonal schools. Gitpod Classic will be officially discontinued after [April 2025](https://www.gitpod.io/blog/introducing-gitpod-flex-faq).

TLDR; For now, I believe the safest is to migrate to GitHub Codespaces, and to re-evaluate Gitpod Flex (self-hosted) at a later stage. We expect all participants to have a GitHub account, so Codespaces is directly available to them.

More info:

- GitHub Codespaces has a generous free tier ([120 core-hours per month](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-codespaces/about-billing-for-github-codespaces#monthly-included-storage-and-core-hours-for-personal-accounts)), which should be more than sufficient for running a 2-core machine for 5 days for 8 hours.
- Gitpod Flex, on the other hand, can be used to spin up development environments either locally, using their desktop application (currently only MacOS is supported), or on your own cloud infrastructure. AWS is supported by means of CloudFormation templates.

Both GitHub Codespaces and Gitpod Flex make use of the [devcontainer specification](https://containers.dev/implementors/spec/), and .gitpod.yaml will be deprecated. Gitpod offers a tool to migrate from .gitpod.yaml to a devcontainer configuration and their custom automations format which is used for running long-lived services and/or tasks (think Makefile / shell scripts).